### PR TITLE
Fix nodejs_image entry point

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -15,5 +15,5 @@ filegroup(
 nodejs_image(
     name = "server",
     data = ["files"],
-    entry_point = "server/src/index.js",
+    entry_point = "$(location src/index.js)",
 )


### PR DESCRIPTION
This works for me with `bazel build //...` on Bazel 1.2.1